### PR TITLE
13750: saveAsXLS: do not print columns with colspan=0

### DIFF
--- a/elu_w2ui.js
+++ b/elu_w2ui.js
@@ -945,6 +945,8 @@ w2obj.grid.prototype.saveAsXLS = function (fn, cb) {
 
                 data.head[i].forEach(function(th) {
 
+                    if (th.colspan == 0) return;
+
                     var colspan = th.colspan || 1
                     var rowspan = th.rowspan || 1
 


### PR DESCRIPTION
исправление 2 ситуаций
1 - в xls выводилась колонка, которая в таблице выводится сверху от полосы прокрутки
2 - при скрытии всех колонок группы название группы колонок всё равно выводилось и приводило к смещению остальных колонок